### PR TITLE
Point alignment fix

### DIFF
--- a/frontend/src/components/Scene.tsx
+++ b/frontend/src/components/Scene.tsx
@@ -89,9 +89,10 @@ export function Scene() {
     let bestDistSq = HOVER_NDC_RADIUS * HOVER_NDC_RADIUS;
     for (let i = 0; i < points.length; i++) {
       const p = points[i];
-      const x = p.coords_3d?.[0] ?? p.coords_2d[0];
-      const y = p.coords_3d?.[1] ?? p.coords_2d[1];
-      const z = p.coords_3d?.[2] ?? 0;
+      const use3d = p.coords_3d && p.coords_3d.length === 3;
+      const x = use3d ? p.coords_3d![0] : p.coords_2d[0];
+      const y = use3d ? p.coords_3d![1] : p.coords_2d[1];
+      const z = use3d ? p.coords_3d![2] : 0;
       worldPos.current.set(x, y, z).applyMatrix4(matrixWorld);
       ndc.current.copy(worldPos.current).project(camera);
       const dx = ndc.current.x - mouse.current.x;
@@ -175,9 +176,10 @@ export function Scene() {
       {hoveredId != null && (() => {
         const p = points.find((x) => String(x.id) === String(hoveredId));
         if (!p) return null;
-        const x = p.coords_3d?.[0] ?? p.coords_2d[0];
-        const y = p.coords_3d?.[1] ?? p.coords_2d[1];
-        const z = p.coords_3d?.[2] ?? 0;
+        const use3d = p.coords_3d && p.coords_3d.length === 3;
+        const x = use3d ? p.coords_3d![0] : p.coords_2d[0];   // condition ? valueIfTrue : valueIfFalse
+        const y = use3d ? p.coords_3d![1] : p.coords_2d[1];
+        const z = use3d ? p.coords_3d![2] : 0;
         return (
           <mesh position={[x, y, z]}>
             <sphereGeometry args={[0.06, 16, 16]} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core hover hit-testing algorithm in the render loop, which can affect interaction accuracy and frame-time performance with large point counts.
> 
> **Overview**
> Fixes point hover/selection alignment by replacing the plane-raycast + `kdTree.nearestNeighbor` world-space radius check with per-point projection into normalized device coordinates (NDC) and selecting the closest point within an NDC radius.
> 
> Removes the `kdTree` dependency from `Scene.tsx`, adds reusable `THREE.Vector3` refs to avoid per-frame allocations, and updates the hovered highlight marker to render at the point’s `coords_3d` (falling back to `coords_2d`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b57bd20bd3b61c468ccf81c9c7f0ff11f8f1bc02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->